### PR TITLE
LAB-909: Add Method 41 Bedrock PassRole + CreateCodeInterpreter privesc query

### DIFF
--- a/pkg/graph/queries/enrich/aws/extract_role_trusted_services.yaml
+++ b/pkg/graph/queries/enrich/aws/extract_role_trusted_services.yaml
@@ -9,6 +9,7 @@ cypher: |
   WHERE role.assumeRolePolicyDoc IS NOT NULL
   WITH role,
     [service IN [
+      'bedrock.amazonaws.com',
       'ec2.amazonaws.com',
       'lambda.amazonaws.com',
       'glue.amazonaws.com',

--- a/pkg/graph/queries/enrich/aws/privesc/method_41_bedrock_createcodeinterpreter.yaml
+++ b/pkg/graph/queries/enrich/aws/privesc/method_41_bedrock_createcodeinterpreter.yaml
@@ -1,0 +1,28 @@
+name: Privesc Method 41 - Bedrock PassRole CreateCodeInterpreter
+description: Creates CAN_PRIVESC relationship when a principal can pass roles to Bedrock AgentCore and create code interpreters for arbitrary code execution
+impactedServices:
+  - IAM
+  - Bedrock
+severity: High
+order: 138
+cypher: |
+  MATCH (principal)-[:IAM_PASSROLE]->(targetRole:AWS_IAM_Role)
+  WHERE principal.admin IS NULL
+    AND 'bedrock.amazonaws.com' IN targetRole.trustedServices
+    AND EXISTS((principal)-[:`BEDROCK-AGENTCORE_CREATECODEINTERPRETER`]->())
+    AND EXISTS((principal)-[:`BEDROCK-AGENTCORE_STARTCODEINTERPRETERSESSION`]->())
+    AND EXISTS((principal)-[:`BEDROCK-AGENTCORE_INVOKECODEINTERPRETER`]->())
+
+  // Create the privesc relationship
+  MERGE (principal)-[privesc:CAN_PRIVESC]->(targetRole)
+  ON CREATE SET
+    privesc.method = "Method-41-Bedrock-PassRole-CreateCodeInterpreter",
+    privesc.requires = ["iam:PassRole", "bedrock-agentcore:CreateCodeInterpreter", "bedrock-agentcore:StartCodeInterpreterSession", "bedrock-agentcore:InvokeCodeInterpreter"],
+    privesc.service = "Bedrock",
+    privesc.targetType = "Role"
+  ON MATCH SET
+    privesc.method = CASE
+      WHEN NOT privesc.method CONTAINS "Method-41-Bedrock-PassRole-CreateCodeInterpreter"
+      THEN privesc.method + ",Method-41-Bedrock-PassRole-CreateCodeInterpreter"
+      ELSE privesc.method
+    END


### PR DESCRIPTION
## Summary
- Add Method 41 Cypher query detecting principals with `iam:PassRole` + `bedrock-agentcore:CreateCodeInterpreter` + `StartCodeInterpreterSession` + `InvokeCodeInterpreter` targeting Bedrock-trusted roles
- Add `bedrock.amazonaws.com` to the trusted services extraction enrichment query

## Test plan
- [x] Deployed testing infra and ran Apollo scan
- [x] Confirmed enrichment query populates `trustedServices` with `bedrock.amazonaws.com` on target roles
- [x] Validated Method 41 CAN_PRIVESC relationship created with correct method, requires, and service metadata
- [x] Cleaned up testing infra